### PR TITLE
Fix GitHub action error

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "998930e4482b67d469d6e672d9c3e33f6b6370287384a75df316b00b5d8e5958"
+            "sha256": "774a679401e642b6e9586cce45f05bfd60d1cf593cb828355f5fc4015de351a2"
         },
         "pipfile-spec": 6,
         "requires": {},

--- a/fib.py
+++ b/fib.py
@@ -8,6 +8,8 @@ Los números negativos no son aceptados
 def fibonacci(position):
   if(position < 0):
     raise ValueError("Invalid input")
+  if(position == 0):
+    return 0
   if(position == 1 or position == 2):
     return 1
   return fibonacci(position - 1) + fibonacci(position - 2)


### PR DESCRIPTION
# This PR fixes the failed github actions test 

## Error 1: Failed to install dependencies
For this error the sha256 in `Pipfile.lock` was out of date, so it was changed according to the suggestion given by the error message

## Error 2: Failed assertion 
This error was caused by the fibonaccci function in `fib.py` , this function missed the if statement to return 0 when the input is also 0. I tested this issue locally by running the function

![image](https://github.com/user-attachments/assets/ba3bb8ed-add9-4435-ae8e-7cc6acf6578b)


